### PR TITLE
Update lib.rs

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![feature(const_type_id)]
 #![allow(clippy::type_complexity)]
 
 // Crate import only


### PR DESCRIPTION
removed #![feature(const_type_id)] because it forces user to use rust nightly