### PR TITLE
fix camera viewport size on scaled target

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -815,7 +815,7 @@ pub fn system_fetch_dimension_from_camera<const INDEX: usize>(
     };
 
     // Pipe the camera viewport size
-    if let Some(cam_size) = camera.physical_viewport_size() {
+    if let Some(cam_size) = camera.logical_viewport_size() {
         for mut size in &mut dst_query {
             **size = Vec2::from((cam_size.x as f32, cam_size.y as f32)) * if let Some(p) = projection_option { p.scale } else { 1.0 };
         }


### PR DESCRIPTION
On scaled target, calculations based on the camera viewport's size were off, due to taking into account the scaling factor. Scaling factor should be taken into account when rendering UI elements, not when placing them into the world, since the world uses logical units.

Example of the bug:
The systems defines a scaling factor of 2. This means that when rendering at 1000x500, the camera is going to upscale that to 2000x1000. If we place a UiLayout that is of size Rl(100.), it's going to take viewport's physical size: 2000x1000. When rendering, it's going to be upscaled by the scale factor, so it'll end up taking 4000x2000.

The fix is to use the camera's viewport logical size, to use world's coordinates.


I'm new to this stuff, the fix might have side effects that I'm not aware of.