### PR TITLE
can we rotate debug gizmos?

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -264,7 +264,7 @@ pub fn system_debug_draw_gizmo_2d(
     for (transform, dimension) in &query {
         // Draw the gizmo outline
         gizmos.rect(
-            Isometry3d::from(transform.translation()),
+            Isometry3d::new(transform.translation(), transform.rotation()),
             **dimension,
             Color::linear_rgb(0.0, 1.0, 0.0),
         );
@@ -279,7 +279,7 @@ pub fn system_debug_draw_gizmo_3d(
     for (transform, dimension) in &query {
         // Draw the gizmo outline
         gizmos.rect(
-            Isometry3d::from(transform.translation()),
+            Isometry3d::new(transform.translation(), transform.rotation()),
             **dimension,
             Color::linear_rgb(0.0, 1.0, 0.0),
         );


### PR DESCRIPTION
with:

https://github.com/user-attachments/assets/b02c00df-9605-4806-94ac-8719534d076a

without:


https://github.com/user-attachments/assets/c459c03e-2004-4b04-8ce7-e15c125b7887


NOTE: `system_debug_draw_gizmo_3d` didn't actually do anything for this (maybe i shouldn't edit it?)