### PR TITLE
Fixing picking behaviour for multiple cameras

### DIFF
--- a/crate/src/lib.rs
+++ b/crate/src/lib.rs
@@ -1157,8 +1157,8 @@ pub struct LunexGizmoGroup3d;
 
 /// This plugin is used for the main logic.
 #[derive(Debug, Default, Clone)]
-pub struct UiLunexPlugin;
-impl Plugin for UiLunexPlugin {
+pub struct UiLunexPlugin<const INDEX: usize>;
+impl<const INDEX: usize> Plugin for UiLunexPlugin<INDEX> {
     fn build(&self, app: &mut App) {
 
         // Configure the system set
@@ -1220,7 +1220,7 @@ impl Plugin for UiLunexPlugin {
         app.add_plugins((
             CursorPlugin,
             UiLunexStatePlugin,
-            UiLunexPickingPlugin,
+            UiLunexPickingPlugin::<INDEX>,
             UiLunexIndexPlugin::<0>,
             UiLunexIndexPlugin::<1>,
             UiLunexIndexPlugin::<2>,
@@ -1264,7 +1264,7 @@ impl <const GIZMO_2D_LAYER: usize, const GIZMO_3D_LAYER: usize> Plugin for UiLun
 /// This plugin is used to register index components.
 #[derive(Debug, Default, Clone)]
 pub struct UiLunexIndexPlugin<const INDEX: usize>;
-impl <const INDEX: usize> Plugin for UiLunexIndexPlugin<INDEX> {
+impl<const INDEX: usize> Plugin for UiLunexIndexPlugin<INDEX> {
     fn build(&self, app: &mut App) {
         app.add_systems(PostUpdate, (
             system_fetch_dimension_from_camera::<INDEX>,
@@ -1275,8 +1275,8 @@ impl <const INDEX: usize> Plugin for UiLunexIndexPlugin<INDEX> {
 
 
 /// Plugin group adding all necessary plugins for Lunex
-pub struct UiLunexPlugins;
-impl PluginGroup for UiLunexPlugins {
+pub struct UiLunexPlugins<const INDEX: usize>;
+impl<const INDEX: usize> PluginGroup for UiLunexPlugins<INDEX> {
     fn build(self) -> PluginGroupBuilder {
         let mut builder = PluginGroupBuilder::start::<Self>();
 
@@ -1289,7 +1289,7 @@ impl PluginGroup for UiLunexPlugins {
         }
 
         // Add Lunex plugin
-        builder = builder.add(UiLunexPlugin);
+        builder = builder.add(UiLunexPlugin::<INDEX>);
 
         // Return the plugin group
         builder

--- a/crate/src/picking.rs
+++ b/crate/src/picking.rs
@@ -13,17 +13,17 @@ use crate::*;
 
 /// Adds picking support for Lunex.
 #[derive(Clone)]
-pub struct UiLunexPickingPlugin;
-impl Plugin for UiLunexPickingPlugin {
+pub struct UiLunexPickingPlugin<const INDEX: usize>;
+impl<const INDEX: usize> Plugin for UiLunexPickingPlugin<INDEX> {
     fn build(&self, app: &mut App) {
-        app.add_systems(PreUpdate, lunex_picking.in_set(PickSet::Backend));
+        app.add_systems(PreUpdate, lunex_picking::<INDEX>.in_set(PickSet::Backend));
     }
 }
 
 /// Checks if any Dimension entities are under a pointer.
-pub fn lunex_picking(
+pub fn lunex_picking<const INDEX: usize>(
     pointers: Query<(&PointerId, &PointerLocation)>,
-    cameras: Query<(Entity, &Camera, &GlobalTransform, &OrthographicProjection)>,
+    cameras: Query<(Entity, &Camera, &GlobalTransform, &OrthographicProjection), With<UiSourceCamera<INDEX>>>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     sprite_query: Query<(
         Entity,

--- a/examples/mesh2d/src/main.rs
+++ b/examples/mesh2d/src/main.rs
@@ -3,7 +3,7 @@ use bevy_lunex::prelude::*;
 
 fn main() -> AppExit {
     App::new()
-        .add_plugins((DefaultPlugins, UiLunexPlugins, UiLunexDebugPlugin::<0, 0>))
+        .add_plugins((DefaultPlugins, UiLunexPlugins::<0>, UiLunexDebugPlugin::<0, 0>))
         .add_systems(Startup, setup)
         .run()
 }

--- a/examples/sprite2d/src/main.rs
+++ b/examples/sprite2d/src/main.rs
@@ -3,7 +3,7 @@ use bevy_lunex::prelude::*;
 
 fn main() -> AppExit {
     App::new()
-        .add_plugins((DefaultPlugins, UiLunexPlugins, UiLunexDebugPlugin::<0, 0>))
+        .add_plugins((DefaultPlugins, UiLunexPlugins::<0>, UiLunexDebugPlugin::<0, 0>))
         .add_systems(Startup, setup)
         .run()
 }

--- a/examples/sprite3d/src/main.rs
+++ b/examples/sprite3d/src/main.rs
@@ -6,7 +6,7 @@ use boilerplate::*;
 
 fn main() -> AppExit {
     App::new()
-        .add_plugins((DefaultPlugins, UiLunexPlugins, UiLunexDebugPlugin::<0, 0>))
+        .add_plugins((DefaultPlugins, UiLunexPlugins::<0>, UiLunexDebugPlugin::<0, 0>))
         .add_systems(Startup, setup)
 
         // This is required for the showcase, not necessary for UI

--- a/examples/text3d/src/main.rs
+++ b/examples/text3d/src/main.rs
@@ -10,7 +10,7 @@ fn main() -> AppExit {
     App::new()
         .add_plugins((
             DefaultPlugins,
-            UiLunexPlugins.set(Text3dPlugin {
+            UiLunexPlugins::<0>.set(Text3dPlugin {
                 // If we use custom fonts we need to load them here.
                 load_font_directories: vec!["assets/fonts".to_owned()],
                 load_system_fonts: true,


### PR DESCRIPTION
Before this change, the picking system would pick the first camera in the query (Entity, &Camera, &GlobalTransform, &OrthographicProjection). This means there isn't any way to match the picking camera chosen with the camera used in viewport calculations. This matters for projects that use multiple Orthographic cameras, particularly with different transformations. An example use case is a game that might used a fixed camera for the UI(lunex) and a dynamic camera for gameplay. Changing the gameplay camera transform will invalidate the picking raycasts, causing the UI to render correctly but not be interactive or have incorrect hit boxes.